### PR TITLE
Lawnchair: Override other launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,4 @@ In case of Paranoid Android, this can be done by appending the following at `ven
 
 `$(call inherit-product-if-exists, vendor/lawnchair/lawnchair.mk)`
 
-**3. Remove existing launcher from the build**
-
-In case of Paranoid Android, this can be done by removing `ParanoidQuickStep` from `vendor/pa/config/common.mk` and `vendor/pa/config/packages.mk`.
-
-**4. Build Android**
+**3. Build Android**

--- a/priv-app/Lawnchair/Android.mk
+++ b/priv-app/Lawnchair/Android.mk
@@ -7,5 +7,5 @@ LOCAL_SRC_FILES := Lawnchair.apk
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT)/priv-app/Lawnchair
-
+LOCAL_OVERRIDES_PACKAGES := ParanoidQuickStep Launcher3QuickStep PixelLauncher TrebuchetQuickStep
 include $(BUILD_PREBUILT)


### PR DESCRIPTION
This removes the necessity to edit vendor/pa/config/common.mk
The overrides includes the most common launchers in AOSP

Signed-off-by: Anirudh Gupta <anirudhgupta109@aosip.dev>